### PR TITLE
implemented model tree inclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 dist
 .tmp
 .sass-cache
+.log
 bower_components

--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ A node utility to simplify schema and model management. Most utility is wrapped 
             - [`prop.less(limit, [message])`](#proplesslimit-message)
             - [`prop.integer([message])`](#propintegermessage)
 - [Utilities](#utilities)
-  - [`mon.drop(collection)`](#mondropcollection)
-  - [`mon.connect([options])`](#monconnectoptions)
-  - [`mon.schema(schema)`](#monschemaschema)
-  - [`mon.model(modelName)`](#monmodelmodelname)
-  - [`mon.new(modelName)`](#monnewmodelname)
-  - [`mon.register(schema, [options])`](#monregisterschema-options)
+    - [`mon.drop(collection)`](#mondropcollection)
+    - [`mon.connect([options])`](#monconnectoptions)
+    - [`mon.schema(schema)`](#monschemaschema)
+    - [`mon.model(modelName)`](#monmodelmodelname)
+    - [`mon.new(modelName)`](#monnewmodelname)
+    - [`mon.register(schema, [options])`](#monregisterschema-options)
+    - [`mon.registerAll(directory, [regex])`](#monregisteralldirectory-regex)
+- [Tests](#running-unit-tests)
 
 
 
@@ -582,6 +584,47 @@ mon.register('Person', {
   }
 });
 ```
+
+### `mon.registerAll(directory, [regex])`
+
+traverses the directory tree 'requireing' all js files (to register models on server startup). optional regex to filter files
+
+**./models/foo.js**
+
+```javascript
+var mon = require('mongoman');
+mon.register('foo', { foo : mon().string().fin() });
+```
+
+**./models/sub_models/bar_model.js**
+
+```javascript
+var mon = require('mongoman');
+mon.register('bar', { bar : mon().string().fin() });
+```
+
+**./server.js**
+
+```javascript
+// ... server setup
+
+mon.connect();
+
+mon.registerAll('../models', /_models/); // registers ['bar']
+
+// OR
+
+mon.registerAll('../models'); // registers ['foo', 'bar']
+
+// ... server finalizing
+```
+
+
+
+
+
+
+
 
 
 # Running Unit Tests

--- a/lib/mongoman.js
+++ b/lib/mongoman.js
@@ -38,6 +38,31 @@ mongoman.configure = function (options) {
   config = _.defaults(options, config.defaults);
 }
 
+// require a tree of js files to aid in model registration
+//
+mongoman.registerAll = function (path, regEx) {
+  // recursive tree for requiring content which matches regex
+  (function traverseSubtree (currentLeaf, currentPath) {
+    currentLeaf = currentLeaf || {};
+
+    // for the current leaf, iterate over its contents
+    _.each(utils.getDirContents(currentPath), function (content) {
+      currentLeaf[content.name] = currentLeaf[content.name] || {};
+
+      // if this is is a file, require it
+      var passesFilter = !regEx || (regEx.test(content.name));
+      if (content.isJs && passesFilter) {
+        require(content.path + '/' + content.name);
+
+      // if it's a directory, recurse
+      } else if (!content.isFile) {
+        traverseSubtree(_.clone(currentLeaf[content.name], true), content.path + '/' + content.name);
+      }
+    });
+  }(null,  path));
+}
+
+
 // register a model with the given schema
 //
 mongoman.register = function (name, schema, options) {

--- a/lib/mongoman.js
+++ b/lib/mongoman.js
@@ -69,39 +69,39 @@ mongoman.register = function (name, schema, options) {
 
   var newSchema = new Schema(schema, options || { strict: true });
 
-  if (utils.isObject(options)) {
+  if (_.isObject(options)) {
 
     // bind index
     //
-    if (utils.isObject(options.index)) {
+    if (_.isObject(options.index)) {
       newSchema.index(options.index);
     }
 
     // bind virtuals
     //
-    if (utils.isObject(options.virtuals)) {
+    if (_.isObject(options.virtuals)) {
       _.each(options.virtuals, function (virtual, key) {
         if (virtual) {
-          if (utils.isFunc(virtual.get)) { newSchema.virtual(key).get(virtual.get); }
-          if (utils.isFunc(virtual.set)) { newSchema.virtual(key).set(virtual.set); }
+          if (_.isFunction(virtual.get)) { newSchema.virtual(key).get(virtual.get); }
+          if (_.isFunction(virtual.set)) { newSchema.virtual(key).set(virtual.set); }
         }
       });
     }
 
     // bind middleware
     //
-    if (utils.isObject(options.middleware)) {
-      if (utils.isObject(options.middleware.pre)) {
+    if (_.isObject(options.middleware)) {
+      if (_.isObject(options.middleware.pre)) {
         _.each(options.middleware.pre, function (preFunc, trigger) {
-          if (utils.isFunc(preFunc)) {
+          if (_.isFunction(preFunc)) {
             newSchema.pre(trigger, preFunc);
           }
         });
       }
 
-      if (utils.isObject(options.middleware.post)) {
+      if (_.isObject(options.middleware.post)) {
         _.each(options.middleware.post, function (postFunc, trigger) {
-          if (utils.isFunc(postFunc)) {
+          if (_.isFunction(postFunc)) {
             newSchema.post(trigger, postFunc);
           }
         });
@@ -110,13 +110,13 @@ mongoman.register = function (name, schema, options) {
 
     // bind methods
     //
-    if (utils.isObject(options.methods)) {
+    if (_.isObject(options.methods)) {
       newSchema.methods = options.methods;
     }
 
     // bind statics
     //
-    if (utils.isObject(options.statics)) {
+    if (_.isObject(options.statics)) {
       newSchema.statics = options.statics;
     }
   }

--- a/lib/property_builder.js
+++ b/lib/property_builder.js
@@ -59,13 +59,13 @@ function PropertyBuilder (propName, strict) {
     return this.validate(msg || (propName ?  propName + ' must be at least ' + min : 'must be at least ' + min), function (value) {
 
       // Array or String
-      if (utils.isString(value) || utils.isArray(value) || utils.isBuffer(value)) {
+      if (_.isString(value) || _.isArray(value) || _.isBuffer(value)) {
         return value.length >= min;
 
-      } else if (utils.isDate(value) || utils.isNumber(value)) {
+      } else if (_.isDate(value) || _.isNumber(value)) {
         return value >= min;
 
-      } else if (utils.isObject(value)) {
+      } else if (_.isObject(value)) {
         return Object.keys(value).length >= min;
 
       } else {
@@ -79,13 +79,13 @@ function PropertyBuilder (propName, strict) {
     return this.validate(msg || (propName ?  propName + ' must be no more than ' + max : 'must be no more than ' + max), function (value) {
 
       // Array or String
-      if (utils.isString(value) || utils.isArray(value) || utils.isBuffer(value)) {
+      if (_.isString(value) || _.isArray(value) || _.isBuffer(value)) {
         return value.length <= max;
 
-      } else if (utils.isDate(value) || utils.isNumber(value)) {
+      } else if (_.isDate(value) || _.isNumber(value)) {
         return value <= max;
 
-      } else if (utils.isObject(value)) {
+      } else if (_.isObject(value)) {
         return Object.keys(value).length <= max;
 
       } else {
@@ -99,10 +99,10 @@ function PropertyBuilder (propName, strict) {
     return this.validate(msg || (propName ?  propName + ' must be exactly ' + length : 'must be exactly ' + length), function (value) {
 
       // Array or String
-      if (utils.isString(value) || utils.isArray(value) || utils.isBuffer(value)) {
+      if (_.isString(value) || _.isArray(value) || _.isBuffer(value)) {
         return value.length === length;
 
-      } else if (utils.isObject(value)) {
+      } else if (_.isObject(value)) {
         return Object.keys(value).length === length;
 
       } else {
@@ -129,7 +129,7 @@ function PropertyBuilder (propName, strict) {
       var isSparse = false;
 
       // only worry about arrays
-      if (utils.isArray(value)) {
+      if (_.isArray(value)) {
         _.each(value, function (val, index) {
           if (val === undefined) {
             isSparse = true;
@@ -153,7 +153,7 @@ function PropertyBuilder (propName, strict) {
   //  Alphanum
   Property.prototype.alphanum = function (msg) {
     return this.validate(msg || (propName ? propName + ' should contain alpha-numeric characters only' : 'alpha-numeric characters only'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return /^[a-z0-9]+$/i.test(value);
 
       }  else {
@@ -166,7 +166,7 @@ function PropertyBuilder (propName, strict) {
   //  Regex
   Property.prototype.regex = function (regex, msg) {
     return this.validate(msg || (propName ? propName + ' is invalid' : 'invalid value'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return regex.test(value);
 
       } else {
@@ -178,7 +178,7 @@ function PropertyBuilder (propName, strict) {
   //  Email
   Property.prototype.email = function (msg) {
     return this.validate(msg || (propName ? propName + ' is not a valid email' : 'invalid email'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return utils.regexSet.email.test(value);
 
       } else {
@@ -190,7 +190,7 @@ function PropertyBuilder (propName, strict) {
   //  Token
   Property.prototype.token = function (msg) {
     return this.validate(msg || (propName ? propName + ' is not a valid token' : 'invalid token'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return utils.regexSet.token.test(value);
 
       } else {
@@ -202,7 +202,7 @@ function PropertyBuilder (propName, strict) {
   //  Guid
   Property.prototype.guid = function (msg) {
     return this.validate(msg || (propName ? propName + ' is not a valid GUID' : 'invalid GUID'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return utils.regexSet.guid.test(value);
 
       } else {
@@ -214,7 +214,7 @@ function PropertyBuilder (propName, strict) {
   //  Host name
   Property.prototype.hostname = function (msg) {
     return this.validate(msg || (propName ? propName + ' is not a valid host name' : 'invalid host name'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return utils.regexSet.host.test(value);
 
       } else {
@@ -226,7 +226,7 @@ function PropertyBuilder (propName, strict) {
   //  url
   Property.prototype.url = function (msg) {
     return this.validate(msg || (propName ? propName + ' is not a valid url' : 'invalid url'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return utils.regexSet.url.test(value);
 
       } else {
@@ -238,7 +238,7 @@ function PropertyBuilder (propName, strict) {
   //  Uppercase
   Property.prototype.uppercase = function (msg) {
     return this.validate(msg || (propName ? propName + ' must be upper case' : 'must be upper case'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return value === value.toUpperCase();
 
       } else {
@@ -250,7 +250,7 @@ function PropertyBuilder (propName, strict) {
   //  Lowercase
   Property.prototype.lowercase = function (msg) {
     return this.validate(msg || (propName ? propName + ' must be lower case' : 'must be lower case'), function (value) {
-      if (utils.isString(value)) {
+      if (_.isString(value)) {
         return value === value.toLowerCase();
 
       } else {
@@ -268,7 +268,7 @@ function PropertyBuilder (propName, strict) {
   // greater than
   Property.prototype.greater = function (greater, msg) {
     return this.validate(msg || (propName ? propName + ' must be greater than ' + greater : 'must be greater than ' + greater), function (value) {
-      if (utils.isNumber(value)) {
+      if (_.isNumber(value)) {
         return value > greater;
 
       } else {
@@ -280,7 +280,7 @@ function PropertyBuilder (propName, strict) {
   // Less than
   Property.prototype.less = function (less, msg) {
     return this.validate(msg || (propName ? propName + ' must be less than ' + less : 'must be less than ' + less), function (value) {
-      if (utils.isNumber(value)) {
+      if (_.isNumber(value)) {
         return value < less;
 
       } else {
@@ -292,7 +292,7 @@ function PropertyBuilder (propName, strict) {
   // Integer
   Property.prototype.integer = function (msg) {
     return this.validate(msg || (propName ? propName + ' must be an integer' : 'must be an integer'), function (value) {
-      if (utils.isNumber(value)) {
+      if (_.isNumber(value)) {
         return (value === parseInt(value, 10));
 
       } else {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,17 +3,13 @@ var fs = require('fs');
 
 
 //
-// Type checking
+// Lodash mixins
 //
 
-exports.isString = function (target) { return (typeof target === 'string');}
-exports.isObject = function (target) { return (typeof target === 'object'); }
-exports.isArray  = function (target) { return (target && target.constructor === Array); }
-exports.isNumber = function (target) { return (typeof target === 'number'); }
-exports.isDate   = function (target) { return (target instanceof Date); }
-exports.isBuffer = function (target) { return (target instanceof Buffer); }
-exports.isBool   = function (target) { return (target === false || target === true); }
-exports.isFunc   = function (target) { return (typeof target=== 'function'); }
+
+_.mixin({
+  isBuffer : function (target) { return (target instanceof Buffer); }
+});
 
 
 //

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,22 +1,57 @@
+var _  = require('lodash');
+var fs = require('fs');
+
 
 //
 // Type checking
 //
 
-module.exports.isString = function (target) { return (typeof target === 'string');}
-module.exports.isObject = function (target) { return (typeof target === 'object'); }
-module.exports.isArray  = function (target) { return (target && target.constructor === Array); }
-module.exports.isNumber = function (target) { return (typeof target === 'number'); }
-module.exports.isDate   = function (target) { return (target instanceof Date); }
-module.exports.isBuffer = function (target) { return (target instanceof Buffer); }
-module.exports.isBool   = function (target) { return (target === false || target === true); }
-module.exports.isFunc   = function (target) { return (typeof target=== 'function'); }
+exports.isString = function (target) { return (typeof target === 'string');}
+exports.isObject = function (target) { return (typeof target === 'object'); }
+exports.isArray  = function (target) { return (target && target.constructor === Array); }
+exports.isNumber = function (target) { return (typeof target === 'number'); }
+exports.isDate   = function (target) { return (target instanceof Date); }
+exports.isBuffer = function (target) { return (target instanceof Buffer); }
+exports.isBool   = function (target) { return (target === false || target === true); }
+exports.isFunc   = function (target) { return (typeof target=== 'function'); }
 
 
-module.exports.regexSet = {
+//
+// Regex's
+//
+
+
+exports.regexSet = {
   email : /^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/,
   token : /^[\w\-]+$/,
   guid  : /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
   host  : /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/,
   url   : /^(https?|ftp):\/\/[^\s\/$.?#].[^\s]*$/i
+}
+
+
+//
+// Misc Utilities
+//
+
+
+// returns the an array of directories and an array of files from an directory
+exports.getDirContents = function (path) {
+  var results = _.map(fs.readdirSync(path) || [], function (content) {
+    if (!content) return;
+
+    var match  = content.match(/(.*?)(\..*)$/) || []
+    var result = {
+      string    : path + '/' + content,
+      name      : match[1] || content,
+      path      : path,
+      extension : match[2] || null,
+      isJs      : /\.js$/.test(content),
+      isFile    : !fs.statSync(path + '/' + (match[1] || content) + (match[2] || '')).isDirectory()
+    };
+
+    return result;
+  });
+
+  return results;
 }

--- a/package.json
+++ b/package.json
@@ -18,16 +18,19 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
+    "fs": "0.0.2",
     "lodash": "2.4.x",
     "mongoose": "3.8.x"
   },
-  "scripts":  {
+  "scripts": {
     "test": "mocha"
   },
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/johnhof/mongoman/blob/master/LICENSE-MIT"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/johnhof/mongoman/blob/master/LICENSE-MIT"
+    }
+  ],
   "devDependencies": {
     "should": "1.1.x",
     "bcrypt-nodejs": "0.0.x",

--- a/test/models/bar_model.js
+++ b/test/models/bar_model.js
@@ -1,0 +1,2 @@
+var Mon = require('../../lib/mongoman');
+Mon.register('bar', { bar : Mon().string().fin() });

--- a/test/models/flat/biz.js
+++ b/test/models/flat/biz.js
@@ -1,0 +1,2 @@
+var Mon = require('../../../lib/mongoman');
+Mon.register('biz', { biz : Mon().string().fin() });

--- a/test/models/flat/buz_model.js
+++ b/test/models/flat/buz_model.js
@@ -1,0 +1,2 @@
+var Mon = require('../../../lib/mongoman');
+Mon.register('buz', { buz : Mon().string().fin() });

--- a/test/models/tree/baz_model.js
+++ b/test/models/tree/baz_model.js
@@ -1,0 +1,2 @@
+var Mon = require('../../../lib/mongoman');
+Mon.register('baz', { baz : Mon().string().fin() });

--- a/test/models/tree/foo.js
+++ b/test/models/tree/foo.js
@@ -1,0 +1,2 @@
+var Mon = require('../../../lib/mongoman');
+Mon.register('foo', { foo : Mon().string().fin() });

--- a/test/models/tree/sub_models/bar_model.js
+++ b/test/models/tree/sub_models/bar_model.js
@@ -1,0 +1,2 @@
+var Mon = require('../../../../lib/mongoman');
+Mon.register('bar', { bar : Mon().string().fin() });

--- a/test/property_builder_test.js
+++ b/test/property_builder_test.js
@@ -1,8 +1,7 @@
 var mon    = require(process.cwd());
 var mocha  = require('mocha');
-var chai   = require('chai');
+var expect = require('chai').expect;
 var db     = mon.connect();
-var expect = chai.expect;
 
 /////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
@DuaneGarber copied and cleaned up https://github.com/johnhof/IceBuddy/blob/master/api/lib/helpers.js#L29 

two tests were added to the end of the execution list.

from README.js
### `mon.registerAll(directory, [regex])`

traverses the directory tree 'requireing' all js files (to register models on server startup). optional regex to filter files

**./models/foo.js**

``` javascript
var mon = require('mongoman');
mon.register('foo', { foo : mon().string().fin() });
```

**./models/sub_models/bar_model.js**

``` javascript
var mon = require('mongoman');
mon.register('bar', { bar : mon().string().fin() });
```

**./server.js**

``` javascript
// ... server setup

mon.connect();

mon.registerAll('../models', /_models/); // registers ['bar']

// OR

mon.registerAll('../models'); // registers ['foo', 'bar']

// ... server finalizing
```
