### PR TITLE
Middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A node utility to simplify schema and model management. Most utility is wrapped 
     - [Universal](#universal)
         - [`prop.set(key, value)`](#propsetkey-value)
         - [`prop.validate(errorMsg, valFunction)`](#propvalidateerrormsg-valfunction)
-        - [`prop.index(key, value)`](#propindexkey-value)
+        - [`prop.index(key|value, [value])`](#propindexkeyvalue-value)
     - [Types](#types)
         - [`prop.string()`](#propstring)
         - [`prop.date()`](#propdate)
@@ -171,12 +171,15 @@ Bind the validation function to the property, throwing the error message if it r
   schema.newProp = mon().validate('newProp must be odd', isOdd).fin();
 ```
 
-### `prop.index(key, value)`
+### `prop.index(key|value, [value])`
 
-Bind the key and value to the index attribute of the property
+Bind the key and value to the index attribute of the property. PRoviding only one parameter will set `index` equal to that parameter
 
 ```javascript
   schema.newProp = mon().index('unique', false).fin();
+  // or
+  schema.newProp = mon().index('hashed').fin();
+
 ```
 
 
@@ -587,7 +590,7 @@ mon.register('Person', {
 
 ### `mon.registerAll(directory, [regex])`
 
-traverses the directory tree 'requireing' all js files (to register models on server startup). optional regex to filter files
+traverses the directory tree requiring all js files (to register models on server startup). optional regex to filter files
 
 **./models/foo.js**
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,21 @@ A node utility to simplify schema and model management. Most utility is wrapped 
         - [`prop.mixed()`](#propmixed)
         - [`prop.objectId()`](#propobjectid)
         - [`prop.array()`](#proparray)
+    - [Middleware](#middleware)
+        - [Shared](#shared)
+            - [`prop.onGet(function)`](#propongetfunction)
+            - [`prop.onSet(function)`](#proponsetfunction)
+        - [Date](#date)
+            - [`expires(dateTime)`](#propexpiresdateTime)
+        - [String](#string)
+            - [`prop.toUppercase()`](#proptouppercase)
+            - [`prop.toLowercase()`](#proptolowercase)
+            - [`prop.trim()`](#proptrim)
     - [Validation](#validation)
         - [Shared](#shared)
             - [`prop.required()`](#proprequired)
             - [`prop.default(value)`](#propdefaultvalue)
+            - [`prop.select([value])`](#propselectvalue)
             - [`prop.enum(values, [message])`](#propenumvalues-message)
             - [`prop.unique([bool])`](#propuniquebool)
             - [`prop.min(value, [message])`](#propminvalue-message)
@@ -259,6 +270,95 @@ Set property type to be `Array`
 
 
 
+# Middleware
+
+Any time `[]` is a function parameter, its is optional.
+
+## Shared
+
+### `prop.onGet(function)`
+
+type: any
+
+Passes the value of the property into the function. the returned value is what is exposed to the document on get
+
+```javascript
+  schema.newProp = mon().onGet(function (value) {
+    return value ? value + '-example' : value;
+  }).fin();
+```
+
+
+### `prop.onSet(function)`
+
+type: any
+
+Passes the value of the property into the function. the returned value is what is saved to the document on get
+
+```javascript
+  schema.newProp = mon().onSet(function (value) {
+    return value ? value + '-example' : value;
+  }).fin();
+```
+
+
+
+
+## Date
+
+
+
+
+
+### `prop.expires(dateTime)`
+
+type: date
+
+Sets the expiration of the date
+
+```javascript
+  schema.newProp = mon().expires('1.5h').fin();
+```
+
+## String
+
+### `prop.toUppercase()`
+
+type: string
+
+Sets the value to uppercase
+
+```javascript
+  schema.newProp = mon().toUppercase().fin();
+```
+
+### `prop.toLowercase()`
+
+type: string
+
+Sets the value lowercase
+
+```javascript
+  schema.newProp = mon().toLowercase().fin();
+```
+
+### `prop.trim()`
+
+type: string
+
+Trims the whitespace off the beginning and end of the string
+
+```javascript
+  schema.newProp = mon().trim().fin();
+```
+
+
+
+
+
+
+
+
 
 # Validation
 
@@ -292,6 +392,17 @@ If no value is set for the property, set it to the default value passed in
 
 ```javascript
   schema.newProp = mon().default('default value').fin();
+```
+
+### `prop.select([bool])`
+
+type: any
+
+`[bool]` true or undefined if this path should always be included in the results, false if it should be excluded by default. This setting can be overridden at the query level.
+
+
+```javascript
+  schema.newProp = mon().select().fin();
 ```
 
 ### `prop.enum(values, [message])`

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Bind the validation function to the property, throwing the error message if it r
 
 ### `prop.index(key|value, [value])`
 
-Bind the key and value to the index attribute of the property. PRoviding only one parameter will set `index` equal to that parameter
+Bind the key and value to the index attribute of the property. Providing only one parameter will set `index` equal to that parameter
 
 ```javascript
   schema.newProp = mon().index('unique', false).fin();

--- a/lib/property_builder.js
+++ b/lib/property_builder.js
@@ -38,13 +38,48 @@ function PropertyBuilder (propName, strict) {
 
   Property.prototype.required = function (required) { return this.set('required', ((required === false) ? false : true)); }
   Property.prototype.default  = function (val) { return this.set('default', val); }
-  Property.prototype.unique   = function (val) { return this.index('unique', ((val === false) ? false : true)); }
+  Property.prototype.select   = function (val) {
+    val = (val === undefined || val === null) ? true : false; // default to true
+    return this.set('select', val);
+  }
   Property.prototype.enum     = function (values, msg) {
     return this.set('enum', {
       values : values || [],
       message : msg || (propName ? propName + ' does not support `{VALUE}`' : '`{VALUE}` is not supported')
     });
   }
+
+
+  /////////////////////////////////////////////////////////////////////////////////
+  //
+  // Middleware
+  //
+  /////////////////////////////////////////////////////////////////////////////////
+
+  Property.prototype.onGet = function (val) { return _.isFunction(val) ? this.set('get', val) : this }
+  Property.prototype.onSet = function (val) { return _.isFunction(val) ? this.set('set', val) : this }
+
+
+  //
+  // Date
+  //
+
+
+  //  Expires
+  Property.prototype.expires = function (dateTime) {
+    return dateTime ? this.set('expires', dateTime) : this;
+  }
+
+
+  //
+  // String
+  //
+
+
+  //  Expires
+  Property.prototype.uppercase = function () { return this.set('uppercase', true); }
+  Property.prototype.lowercase = function () { return this.set('lowercase', true); }
+  Property.prototype.trim      = function () { return this.set('trim', true); }
 
 
   /////////////////////////////////////////////////////////////////////////////////
@@ -332,11 +367,12 @@ function PropertyBuilder (propName, strict) {
   }
 
   Property.prototype.index = function (key, value) {
-    if (this.data.index) {
+    if (key && value !== undefined) {
+      this.data.index = _.isObject(this.data.index) ? this.data.index : {};
       this.data.index[key] = value;
-    } else {
-      this.data.index = {}
-      this.data.index[key] = value;
+
+    } else if (key) {
+      this.data.index = key;
     }
 
     return this;

--- a/lib/property_builder.js
+++ b/lib/property_builder.js
@@ -38,6 +38,7 @@ function PropertyBuilder (propName, strict) {
 
   Property.prototype.required = function (required) { return this.set('required', ((required === false) ? false : true)); }
   Property.prototype.default  = function (val) { return this.set('default', val); }
+  Property.prototype.unique   = function (val) { return this.index('unique', ((val === false) ? false : true)); }
   Property.prototype.select   = function (val) {
     val = (val === undefined || val === null) ? true : false; // default to true
     return this.set('select', val);
@@ -77,9 +78,9 @@ function PropertyBuilder (propName, strict) {
 
 
   //  Expires
-  Property.prototype.uppercase = function () { return this.set('uppercase', true); }
-  Property.prototype.lowercase = function () { return this.set('lowercase', true); }
-  Property.prototype.trim      = function () { return this.set('trim', true); }
+  Property.prototype.toUppercase = function () { return this.set('uppercase', true); }
+  Property.prototype.toLowercase = function () { return this.set('lowercase', true); }
+  Property.prototype.trim        = function () { return this.set('trim', true); }
 
 
   /////////////////////////////////////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mongoman",
   "author": "John Hofrichter <https://github.com/johnhof>",
   "description": "MongoDB management utility",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "repository": "git://github.com/johnhof/mongoman",
   "main": "lib/mongoman.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mongoman",
   "author": "John Hofrichter <https://github.com/johnhof>",
   "description": "MongoDB management utility",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": "git://github.com/johnhof/mongoman",
   "main": "lib/mongoman.js",
   "keywords": [

--- a/test/property_builder_test.js
+++ b/test/property_builder_test.js
@@ -39,14 +39,14 @@ describe('Property Builder', function () {
   //////////////////////////////////////////////////////////////////////////
 
 
-  describe('SchemaType Attributes', function () {
+  describe('Middleware', function () {
 
     //
     // Get
     //
     describe('On Get', function () {
       var val       = 'foo';
-      var addition  = '-test'
+      var addition  = '-test';
       var modelName = 'getModel';
 
       function getTest (value) { return value ? value + addition : value; }
@@ -70,7 +70,7 @@ describe('Property Builder', function () {
     //
     describe('On Set', function () {
       var val       = 'foo';
-      var addition  = '-test'
+      var addition  = '-test';
       var modelName = 'setModel';
 
       function setTest (value) { return value ? value + addition : value; }
@@ -89,51 +89,89 @@ describe('Property Builder', function () {
       });
     });
 
+    describe('Date Middleware', function () {
 
-  //   //
-  //   // Index
-  //   //
-  //   describe('Index', function () {
-  //     var val       = 'foo';
-  //     var modelName = 'getModel';
+      //
+      // Expires
+      //
+      describe('Expires', function () {
+        it('should create expiration time for the property', function (done) {
+          var dateTime  = 1;
+          var prop      = mon().date().expires(dateTime).fin();
 
-  //     mon.register(modelName, {
-  //       prop  : mon().string().index('hashed').fin(),
-  //       other : mon().string().index('expires', '1d').fin(),
+          expect(prop.expires).to.equal(dateTime);
+          done();
+        });
+      });
+    });
 
-  //     });
+    describe('String Middleware', function () {
 
-  //     it('should create get helper for the property', function (done) {
-  //       var model = mon.new(modelName, { prop : val });
-  //       model.save(function (error, result) {
-  //         expect(error).to.equal(null);
-  //         expect(findValue(result, 'prop')).to.equal(val + addition);
-  //         done();
-  //       });
-  //     });
-  //   });
+      //
+      // toUppercase
+      //
+      describe('To Uppercase', function () {
+        var val       = 'foo';
+        var modelName = 'uppercaseModel';
+
+        mon.register(modelName, {
+          prop : mon().string().toUppercase().fin()
+        });
+
+        it('should tranform to uppercase', function (done) {
+          var model = mon.new(modelName, { prop : val });
+          model.save(function (error, result) {
+            expect(error).to.equal(null);
+            expect(findValue(result, 'prop')).to.equal(val.toUpperCase());
+            done();
+          });
+        });
+      });
 
 
-  //   //
-  //   // Select
-  //   //
-  //   describe('Select', function () {
-  //     var val       = 'foo';
-  //     var modelName = 'selectModel';
+      //
+      // toLowercase
+      //
+      describe('To Lowercase', function () {
+        var val       = 'foo';
+        var modelName = 'lowercaseModel';
 
-  //     mon.register(modelName, {
-  //       prop : mon().string().select().fin()
-  //     });
+        mon.register(modelName, {
+          prop : mon().string().toLowercase().fin()
+        });
 
-  //     it('should create get helper for the property', function (done) {
-  //       var model = mon.new(modelName, { prop : val });
-  //       model.save(function (error, result) {
-  //         expect(error).to.equal(null);
-  //         expect(findValue(result, 'prop')).to.equal(val + addition);
-  //         done();
-  //       });
-  //     });
-  //   });
+        it('should transform to lowercase', function (done) {
+          var model = mon.new(modelName, { prop : val });
+          model.save(function (error, result) {
+            expect(error).to.equal(null);
+            expect(findValue(result, 'prop')).to.equal(val.toLowerCase());
+            done();
+          });
+        });
+      });
+
+
+      //
+      // trim
+      //
+      describe('Trim', function () {
+        var val       = ' foo ';
+        var modelName = 'trimModel';
+
+        mon.register(modelName, {
+          prop : mon().string().trim().fin()
+        });
+
+        it('should trim value', function (done) {
+          var model = mon.new(modelName, { prop : val });
+          model.save(function (error, result) {
+            expect(error).to.equal(null);
+            expect(findValue(result, 'prop')).to.equal(val.trim());
+            done();
+          });
+        });
+      });
+    });
   });
 
 

--- a/test/property_builder_test.js
+++ b/test/property_builder_test.js
@@ -32,9 +32,118 @@ describe('Property Builder', function () {
   });
 
 
+  //////////////////////////////////////////////////////////////////////////
+  //
+  // SchemaType attributes
+  //
+  //////////////////////////////////////////////////////////////////////////
+
+
+  describe('SchemaType Attributes', function () {
+
+    //
+    // Get
+    //
+    describe('On Get', function () {
+      var val       = 'foo';
+      var addition  = '-test'
+      var modelName = 'getModel';
+
+      function getTest (value) { return value ? value + addition : value; }
+
+      mon.register(modelName, {
+        prop : mon().string().onGet(getTest).fin()
+      });
+
+      it('should create get middleware for the property', function (done) {
+        var model = mon.new(modelName, { prop : val });
+        model.save(function (error, result) {
+          expect(error).to.equal(null);
+          expect(findValue(result, 'prop')).to.equal(val + addition);
+          done();
+        });
+      });
+    });
+
+    //
+    // Get
+    //
+    describe('On Set', function () {
+      var val       = 'foo';
+      var addition  = '-test'
+      var modelName = 'setModel';
+
+      function setTest (value) { return value ? value + addition : value; }
+
+      mon.register(modelName, {
+        prop : mon().string().onSet(setTest).fin()
+      });
+
+      it('should create set middleware for the property', function (done) {
+        var model = mon.new(modelName, { prop : val });
+        model.save(function (error, result) {
+          expect(error).to.equal(null);
+          expect(findValue(result, 'prop')).to.equal(val + addition);
+          done();
+        });
+      });
+    });
+
+
+  //   //
+  //   // Index
+  //   //
+  //   describe('Index', function () {
+  //     var val       = 'foo';
+  //     var modelName = 'getModel';
+
+  //     mon.register(modelName, {
+  //       prop  : mon().string().index('hashed').fin(),
+  //       other : mon().string().index('expires', '1d').fin(),
+
+  //     });
+
+  //     it('should create get helper for the property', function (done) {
+  //       var model = mon.new(modelName, { prop : val });
+  //       model.save(function (error, result) {
+  //         expect(error).to.equal(null);
+  //         expect(findValue(result, 'prop')).to.equal(val + addition);
+  //         done();
+  //       });
+  //     });
+  //   });
+
+
+  //   //
+  //   // Select
+  //   //
+  //   describe('Select', function () {
+  //     var val       = 'foo';
+  //     var modelName = 'selectModel';
+
+  //     mon.register(modelName, {
+  //       prop : mon().string().select().fin()
+  //     });
+
+  //     it('should create get helper for the property', function (done) {
+  //       var model = mon.new(modelName, { prop : val });
+  //       model.save(function (error, result) {
+  //         expect(error).to.equal(null);
+  //         expect(findValue(result, 'prop')).to.equal(val + addition);
+  //         done();
+  //       });
+  //     });
+  //   });
+  });
+
+
+
+
+  //////////////////////////////////////////////////////////////////////////
   //
   // Shared attributes
   //
+  //////////////////////////////////////////////////////////////////////////
 
 
   describe('Shared Attributes', function () {
@@ -640,9 +749,11 @@ describe('Property Builder', function () {
   }); // END - string
 
 
+  //////////////////////////////////////////////////////////////////////////
   //
   // Number attributes
   //
+  //////////////////////////////////////////////////////////////////////////
 
 
   describe('Number Attributes', function () {


### PR DESCRIPTION
@DuaneGarber  I added Middleare and support for Schema properties specified here https://github.com/johnhof/mongoman/issues/15

there are some potential regressions, make sure to take a good look at my edits on old functionality.

We may want to consider more custom middleware in the future, such as a function to automatically encrypt a string. With this PR, its possible using `schema.password = mon().string().required().onSet(SomeEncryptFunction)`
