### PR TITLE
Adding Schema as a Property Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A node utility to simplify schema and model management. Most utility is wrapped 
         - [`prop.mixed()`](#propmixed)
         - [`prop.objectId()`](#propobjectid)
         - [`prop.array()`](#proparray)
+        - [`prop.schema()`](#propschema)
     - [Middleware](#middleware)
         - [Shared](#shared)
             - [`prop.onGet(function)`](#propongetfunction)
@@ -263,7 +264,16 @@ Set property type to be `Array`
   schema.newProp = mon().array().fin();
 ```
 
+### `prop.schema(ref, type)`
 
+Set property type to be a reference to another schema
+
+```ref```  -- Required - name of referred schema
+```type``` -- Optional - Defaults ```ObjectId```, possible values (```Number```, ```String```, ```Buffer```)
+
+```javascript
+  schema.newProp = mon().schema('schemaName').fin();
+```
 
 
 

--- a/lib/property_builder.js
+++ b/lib/property_builder.js
@@ -27,6 +27,7 @@ function PropertyBuilder (propName, strict) {
   Property.prototype.mixed    = function () { return this.set('type', Schema.Types.Mixed); }
   Property.prototype.objectId = function () { return this.set('type', Schema.Types.ObjectId); }
   Property.prototype.array    = function (type) { return this.set('type', type ? [type] : Array); }
+  Property.prototype.schema   = function (ref, type) { return this.set('ref', ref).set('type', type ? type : Schema.Types.ObjectId); }
 
 
   /////////////////////////////////////////////////////////////////////////////////

--- a/test/property_builder_test.js
+++ b/test/property_builder_test.js
@@ -31,6 +31,29 @@ describe('Property Builder', function () {
     done();
   });
 
+ describe('Schema Property', function () {
+  mon.register('person', {
+    name : mon().string().fin()
+  });
+  mon.register('book', {
+    title : mon().string().fin(),
+    author : mon().schema('person').fin()
+  });
+
+
+  it('should be able to populate a Schema defined inside a Schema', function (done) {
+    var person = mon.new('person', {name : 'Duane'});
+    person.save(function (error, person) {
+      expect(error).to.equal(null);
+      var book = mon.new('book', {title : 'Test Book', author : person['_id']});
+      book.save(function (error, book) {
+          expect(error).to.equal(null);
+          done();
+      });
+    });
+  });
+ });
+
 
   //////////////////////////////////////////////////////////////////////////
   //


### PR DESCRIPTION
@johnhof So you may have already thought this functionality existed but I don't believe it does.

So I added the .schema() property.

This enables documents to be populated via the .populate() mongoose function.

I have tried your other props, they don't work without the ref.

Thoughts?
