### PR TITLE
.ref()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A node utility to simplify schema and model management. Most utility is wrapped 
             - [`prop.select([value])`](#propselectvalue)
             - [`prop.enum(values, [message])`](#propenumvalues-message)
             - [`prop.unique([bool])`](#propuniquebool)
+            - [`prop.ref(model)`](#proprefmodel)
             - [`prop.min(value, [message])`](#propminvalue-message)
             - [`prop.max(value, [message])`](#propmaxvalue-message)
             - [`prop.length(value)`](#proplengthvalue-message)
@@ -433,6 +434,16 @@ Insures a unique index is generated for the property. defaults to true. False ca
 
 ```javascript
   schema.newProp = mon().unique().fin();
+```
+
+### `prop.ref(model)`
+
+type: any
+
+Creates a reference to another model. This is used to populate data from another document
+
+```javascript
+  schema.newProp = mon().objectId().ref('fooModel').fin();
 ```
 
 ### `prop.min(value, [message])`

--- a/lib/property_builder.js
+++ b/lib/property_builder.js
@@ -40,6 +40,7 @@ function PropertyBuilder (propName, strict) {
   Property.prototype.required = function (required) { return this.set('required', ((required === false) ? false : true)); }
   Property.prototype.default  = function (val) { return this.set('default', val); }
   Property.prototype.unique   = function (val) { return this.index('unique', ((val === false) ? false : true)); }
+  Property.prototype.ref      = function (modelName) { return this.set('ref', modelName); }
   Property.prototype.select   = function (val) {
     val = (val === undefined || val === null) ? true : false; // default to true
     return this.set('select', val);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mongoman",
   "author": "John Hofrichter <https://github.com/johnhof>",
   "description": "MongoDB management utility",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": "git://github.com/johnhof/mongoman",
   "main": "lib/mongoman.js",
   "keywords": [

--- a/test/property_builder_test.js
+++ b/test/property_builder_test.js
@@ -476,6 +476,20 @@ describe('Property Builder', function () {
         });
       });
     }); // END - Length
+
+
+    //
+    // Ref
+    //
+    describe('Ref', function () {
+      var model  = 'FooModel';
+
+      // pass
+      it('should create a ref to a model', function (done) {
+        expect(mon().objectId().ref(model).fin().ref).to.equal(model);
+        done();
+      });
+    });// END - enum
   }); // END - Shared attributes
 
 


### PR DESCRIPTION
@DuaneGarber added `.ref(model)` for populate support

to reference our earlier discussion, the same thing could have been accomplished with `.set('ref', { model: 'fooModel '})`
